### PR TITLE
Make M.dict() behave better

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@ repos:
   - hooks:
       - id: black
         language_version: python3
-    repo: https://github.com/ambv/black
-    rev: 21.11b1
+    repo: https://github.com/psf/black
+    rev: 22.3.0
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:

--- a/pytest_test_utils/matchers.py
+++ b/pytest_test_utils/matchers.py
@@ -54,24 +54,21 @@ class any:  # pylint: disable=redefined-builtin
         return True
 
 
-class dict:  # pylint: disable=redefined-builtin
+class _dict(dict):
     """Special class to eq by matching only presented dict keys"""
 
-    def __init__(
-        self, d: Optional[Mapping[Any, Any]] = None, **keys: Any
-    ) -> None:
-        self.d: Dict[Any, Any] = {}
+    def __init__(self, d: Optional[Mapping[Any, Any]] = None, **keys: Any) -> None:
         if d:
-            self.d.update(d)
-        self.d.update(keys)
+            self.update(d)
+        self.update(keys)
 
     def __repr__(self) -> str:
-        inner = ", ".join(f"{k}={repr(v)}" for k, v in self.d.items())
+        inner = ", ".join(f"{k}={repr(v)}" for k, v in self.items())
         return f"dict({inner})"
 
     def __eq__(self, other: object) -> bool:
         assert isinstance(other, collections.abc.Mapping)
-        return all(other.get(name) == v for name, v in self.d.items())
+        return all(other.get(name) == v for name, v in self.items())
 
 
 class unordered:
@@ -186,7 +183,7 @@ class Matcher(attrs):
 
     @staticmethod
     def dict(d: Optional[Mapping[Any, Any]] = None, **keys: Any) -> dict:
-        return dict(d=d, **keys)
+        return _dict(d=d, **keys)
 
     @staticmethod
     def unordered(*items: Any) -> unordered:

--- a/pytest_test_utils/matchers.py
+++ b/pytest_test_utils/matchers.py
@@ -1,17 +1,8 @@
+import builtins
 import collections.abc
 import re
 from datetime import datetime
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    AnyStr,
-    Dict,
-    Mapping,
-    Optional,
-    Pattern,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, AnyStr, Pattern, Tuple, Union
 
 if TYPE_CHECKING:
     from _pytest.python_api import ApproxBase
@@ -54,13 +45,10 @@ class any:  # pylint: disable=redefined-builtin
         return True
 
 
-class _dict(dict):
+class dict(
+    builtins.dict  # type: ignore[type-arg]
+):  # pylint: disable=redefined-builtin
     """Special class to eq by matching only presented dict keys"""
-
-    def __init__(self, d: Optional[Mapping[Any, Any]] = None, **keys: Any) -> None:
-        if d:
-            self.update(d)
-        self.update(keys)
 
     def __repr__(self) -> str:
         inner = ", ".join(f"{k}={repr(v)}" for k, v in self.items())
@@ -167,6 +155,7 @@ class Matcher(attrs):
     """
 
     any = any()
+    dict = dict
 
     @staticmethod
     def attrs(**attribs: Any) -> attrs:
@@ -180,10 +169,6 @@ class Matcher(attrs):
         return regex(pattern, flags=flags)
 
     re = regex
-
-    @staticmethod
-    def dict(d: Optional[Mapping[Any, Any]] = None, **keys: Any) -> dict:
-        return _dict(d=d, **keys)
 
     @staticmethod
     def unordered(*items: Any) -> unordered:

--- a/tests.py
+++ b/tests.py
@@ -125,6 +125,9 @@ def test_matcher_repr(matcher: Type[Matcher]) -> None:
 
 
 def test_matcher_dict(matcher: Type[Matcher]) -> None:
+    # pytest needs len() to be there when there is no explanation
+    assert len(matcher.dict({"a": 1, "b": 2})) == 2
+
     actual = {"base_url": "url", "verify": "bundle", "timeout": 10}
     assert actual == matcher.dict(verify="bundle", timeout=10)
     assert actual == matcher.dict(actual, verify="bundle")

--- a/tests.py
+++ b/tests.py
@@ -109,9 +109,7 @@ def test_matcher_repr(matcher: Type[Matcher]) -> None:
     assert repr(matcher.attrs(foo="foo")) == "attrs(foo='foo')"
     assert repr(matcher.any_of(3, 4)) == "any_of(3, 4)"
     assert (
-        repr(
-            matcher.dict(foo="foo", **{"bar": "bar"})  # type: ignore[arg-type]
-        )
+        repr(matcher.dict(foo="foo", **{"bar": "bar"}))
         == "dict(foo='foo', bar='bar')"
     )
     assert repr(matcher.instance_of(str)) == "instance_of(str)"


### PR DESCRIPTION
- pytest shows more when it knows comparin dicts
- if explanation fails when pytest may call len() on operand