### PR TITLE
Fix M.dict() work with subclasses of a dict and fix repr/classname

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -109,8 +109,8 @@ def test_matcher_repr(matcher: Type[Matcher]) -> None:
     assert repr(matcher.attrs(foo="foo")) == "attrs(foo='foo')"
     assert repr(matcher.any_of(3, 4)) == "any_of(3, 4)"
     assert (
-        repr(matcher.dict(foo="foo", **{"bar": "bar"}))
-        == "dict(foo='foo', bar='bar')"
+        repr(matcher.dict(foo="foo", **{"n": 123}))  # type: ignore[arg-type]
+        == "M.dict(foo='foo', n=123)"
     )
     assert repr(matcher.instance_of(str)) == "instance_of(str)"
     assert (
@@ -130,6 +130,14 @@ def test_matcher_dict(matcher: Type[Matcher]) -> None:
     assert actual == matcher.dict(verify="bundle", timeout=10)
     assert actual == matcher.dict(actual, verify="bundle")
     assert actual != matcher.dict(verify="bundle.pem")
+
+
+def test_matcher_dict_subclass(matcher: Type[Matcher]) -> None:
+    class SubDict(dict):  # type: ignore[type-arg]
+        pass
+
+    assert SubDict(a=1) == matcher.dict()
+    assert matcher.dict() == SubDict(a=1)
 
 
 def test_matcher_regex(matcher: Type[Matcher]) -> None:


### PR DESCRIPTION
Note to @skshetry. Unfortunately sublclassing dict does not work when comparing to other dict subclasses, they think they know how to compare to us.

Also, using `dict` as name and repr proved to cause confusion during debugging. One can't tell from reading stack traces and messages whether this is our dict or built-in one. 

**P.S.** Additionally naming it `dict` confuses `reprlib.Repr`, which tries to handle it like a dict.